### PR TITLE
Makes use of Hotspotimage::TYPE constant to reference correct configuration

### DIFF
--- a/src/GraphQL/QueryFieldConfigGenerator/ImageGallery.php
+++ b/src/GraphQL/QueryFieldConfigGenerator/ImageGallery.php
@@ -55,7 +55,7 @@ class ImageGallery extends Base
      */
     public function getFieldType(Data $fieldDefinition, $class = null, $container = null)
     {
-        $hotspotType = $this->getGraphQlService()->getTypeDefinition("hotspot");
+        $hotspotType = $this->getGraphQlService()->getTypeDefinition(Hotspotimage::TYPE);
         return Type::listOf($hotspotType);
     }
 


### PR DESCRIPTION
Fix for **unknown type: hotspot** thrown in [GraphQL/Service.php](https://github.com/pimcore/data-hub/blob/master/src/GraphQL/Service.php#L449), introduced due to change in graphql.yml